### PR TITLE
[mainnet] fix: set the MongoDB feature compatibility version for upgrade

### DIFF
--- a/mongo/mongoDbPrepare.js
+++ b/mongo/mongoDbPrepare.js
@@ -60,6 +60,8 @@
 	db.createCollection('transactionStatuses', { capped: true, size: 53000000, max: 500000 });
 	db.transactionStatuses.createIndex({ 'status.hash': 1 }, { unique: true });
 	db.transactionStatuses.createIndex({ 'status.deadline': -1 });
+
+	db.adminCommand( { setFeatureCompatibilityVersion: '6.0' } )
 })();
 
 (function preparePluginDbCollections() {


### PR DESCRIPTION
problem: MongoDB checks the feature compatibility version during the upgrade.
       The upgrade will fail if it is not set to the previous release.
     This value does not automatically get set on upgrades.
solution: set the feature compatibility version on upgrade.