### PR TITLE
[sai] fix: add support for importing node key

### DIFF
--- a/shoestring.ini
+++ b/shoestring.ini
@@ -27,6 +27,7 @@ lockedFundsPerAggregate = 10000000
 
 harvester =
 voter =
+node_key =
 
 [node]
 


### PR DESCRIPTION
problem: no way to import the node key from bootstrap
solution: add support for importing the node key