### PR TITLE
[mainnet] fix: add routeExtensions for rest

### DIFF
--- a/rest/rest.json
+++ b/rest/rest.json
@@ -30,6 +30,8 @@
 		"restrictions",
 		"transfer"
 	],
+	"routeExtensions": [
+	],
 	"db": {
 		"url": "mongodb://db:27017/",
 		"name": "catapult",


### PR DESCRIPTION
problem: no routeExtensions in rest config
solution: add routeExtensions to rest config