### PR TITLE
[mainnet] fix: setFeatureCompatibilityVersion fails on mongodb 7

### DIFF
--- a/mongo/mongoDbPrepare.js
+++ b/mongo/mongoDbPrepare.js
@@ -61,7 +61,7 @@
 	db.transactionStatuses.createIndex({ 'status.hash': 1 }, { unique: true });
 	db.transactionStatuses.createIndex({ 'status.deadline': -1 });
 
-	db.adminCommand( { setFeatureCompatibilityVersion: '7.0' } )
+	db.adminCommand( { setFeatureCompatibilityVersion: '7.0', confirm: true } )
 })();
 
 (function preparePluginDbCollections() {


### PR DESCRIPTION
problem: setFeatureCompatibilityVersion fails on mongodb 7 since the confirm is required
solution: add the confirm true in the setFeatureCompatibilityVersion