### PR TITLE
[sai]: add index for transactions.type

### DIFF
--- a/mongo/mongoDbPrepare.js
+++ b/mongo/mongoDbPrepare.js
@@ -40,6 +40,7 @@
 	db.transactions.createIndex({ 'transaction.deadline': -1 });
 	db.transactions.createIndex({ 'transaction.cosignatures.signerPublicKey': 1 }, makeSparse('transaction.cosignatures.signerPublicKey'));
 	db.transactions.createIndex({ 'transaction.id': 1, 'transaction.type': 1 }, makeSparse('transaction.id'));
+	db.transactions.createIndex({ 'transaction.type': 1 });
 
 	db.createCollection('transactionStatements');
 	db.transactionStatements.createIndex(


### PR DESCRIPTION
problem: as MongoDB database grows, search for transaction by type gets slower
solution: add a primary index for transaction.type